### PR TITLE
Update to phpseclib2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "civicrm/civicrm-cxn-rpc",
     "description": "RPC library for CiviConnect",
     "require": {
-        "psr/log": "~1.0",
-        "phpseclib/phpseclib": "1.0.*"
+        "psr/log": "~1.1",
+        "phpseclib/phpseclib": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/AesHelper.php
+++ b/src/AesHelper.php
@@ -19,7 +19,7 @@ class AesHelper {
    *   A secret, expressed in a series of printable ASCII characters.
    */
   public static function createSecret() {
-    return base64_encode(crypt_random_string(Constants::AES_BYTES));
+    return base64_encode(\phpseclib\Crypt\Random::string(Constants::AES_BYTES));
   }
 
   /**
@@ -56,11 +56,11 @@ class AesHelper {
    * @throws InvalidMessageException
    */
   public static function encryptThenSign($secret, $plaintext) {
-    $iv = crypt_random_string(Constants::AES_BYTES);
+    $iv = \phpseclib\Crypt\Random::string(Constants::AES_BYTES);
 
     $keys = AesHelper::deriveAesKeys($secret);
 
-    $cipher = new \Crypt_AES(CRYPT_AES_MODE_CBC);
+    $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\AES::MODE_CBC);
     $cipher->setKeyLength(Constants::AES_BYTES);
     $cipher->setKey($keys['enc']);
     $cipher->setIV($iv);
@@ -116,7 +116,7 @@ class AesHelper {
     }
 
     $jsonPlaintext = UserError::adapt('Civi\Cxn\Rpc\Exception\InvalidMessageException', function () use ($jsonEncrypted, $envelope, $keys) {
-      $cipher = new \Crypt_AES(CRYPT_AES_MODE_CBC);
+      $cipher = new \phpseclib\Crypt\AES(\phpseclib\Crypt\AES::MODE_CBC);
       $cipher->setKeyLength(Constants::AES_BYTES);
       $cipher->setKey($keys['enc']);
       $cipher->setIV(BinHex::hex2bin($envelope['iv']));

--- a/src/AppMeta.php
+++ b/src/AppMeta.php
@@ -19,7 +19,7 @@ class AppMeta {
    * @return string
    */
   public static function createId() {
-    return 'app:' . BinHex::bin2hex(crypt_random_string(Constants::APP_ID_CHARS));
+    return 'app:' . BinHex::bin2hex(\phpseclib\Crypt\Random::string(Constants::APP_ID_CHARS));
   }
 
   public static function validate($appMeta) {

--- a/src/CA.php
+++ b/src/CA.php
@@ -27,22 +27,22 @@ class CA {
    *   Certificate data.
    */
   public static function create($keyPair, $dn) {
-    $privKey = new \Crypt_RSA();
+    $privKey = new \phpseclib\Crypt\RSA();
     $privKey->loadKey($keyPair['privatekey']);
 
-    $pubKey = new \Crypt_RSA();
+    $pubKey = new \phpseclib\Crypt\RSA();
     $pubKey->loadKey($keyPair['publickey']);
     $pubKey->setPublicKey();
 
-    $subject = new \File_X509();
+    $subject = new \phpseclib\File\X509();
     $subject->setDN($dn);
     $subject->setPublicKey($pubKey);
 
-    $issuer = new \File_X509();
+    $issuer = new \phpseclib\File\X509();
     $issuer->setPrivateKey($privKey);
     $issuer->setDN($dn);
 
-    $x509 = new \File_X509();
+    $x509 = new \phpseclib\File\X509();
     $x509->makeCA();
     $x509->setEndDate(date('c', strtotime(Constants::CA_DURATION, Time::getTime())));
 
@@ -85,14 +85,14 @@ class CA {
    *   CSR data.
    */
   public static function createAppCSR($keyPair, $dn) {
-    $privKey = new \Crypt_RSA();
+    $privKey = new \phpseclib\Crypt\RSA();
     $privKey->loadKey($keyPair['privatekey']);
 
-    $pubKey = new \Crypt_RSA();
+    $pubKey = new \phpseclib\Crypt\RSA();
     $pubKey->loadKey($keyPair['publickey']);
     $pubKey->setPublicKey();
 
-    $x509 = new \File_X509();
+    $x509 = new \phpseclib\File\X509();
     $x509->setPrivateKey($privKey);
     $x509->setDN($dn);
 
@@ -117,14 +117,14 @@ class CA {
    *   CSR data.
    */
   public static function createDirSvcCSR($keyPair, $dn) {
-    $privKey = new \Crypt_RSA();
+    $privKey = new \phpseclib\Crypt\RSA();
     $privKey->loadKey($keyPair['privatekey']);
 
-    $pubKey = new \Crypt_RSA();
+    $pubKey = new \phpseclib\Crypt\RSA();
     $pubKey->loadKey($keyPair['publickey']);
     $pubKey->setPublicKey();
 
-    $x509 = new \File_X509();
+    $x509 = new \phpseclib\File\X509();
     $x509->setPrivateKey($privKey);
     $x509->setDN($dn);
 
@@ -144,14 +144,14 @@ class CA {
    *   PEM-encoded CSR.
    */
   public static function createCrlDistCSR($keyPair, $dn) {
-    $privKey = new \Crypt_RSA();
+    $privKey = new \phpseclib\Crypt\RSA();
     $privKey->loadKey($keyPair['privatekey']);
 
-    $pubKey = new \Crypt_RSA();
+    $pubKey = new \phpseclib\Crypt\RSA();
     $pubKey->loadKey($keyPair['publickey']);
     $pubKey->setPublicKey();
 
-    $csr = new \File_X509();
+    $csr = new \phpseclib\File\X509();
     $csr->setPrivateKey($privKey);
     $csr->setPublicKey($pubKey);
     $csr->setDN($dn);
@@ -173,17 +173,17 @@ class CA {
    *   PEM-encoded cert.
    */
   public static function signCSR($caKeyPair, $caCert, $csr, $serialNumber = 1) {
-    $privKey = new \Crypt_RSA();
+    $privKey = new \phpseclib\Crypt\RSA();
     $privKey->loadKey($caKeyPair['privatekey']);
 
-    $subject = new \File_X509();
+    $subject = new \phpseclib\File\X509();
     $subject->loadCSR($csr);
 
-    $issuer = new \File_X509();
+    $issuer = new \phpseclib\File\X509();
     $issuer->loadX509($caCert);
     $issuer->setPrivateKey($privKey);
 
-    $x509 = new \File_X509();
+    $x509 = new \phpseclib\File\X509();
     $x509->setSerialNumber($serialNumber, 10);
     $x509->setEndDate(date('c', strtotime(Constants::APP_DURATION, Time::getTime())));
 

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -30,11 +30,11 @@ class Constants {
    */
   const APP_ID_CHARS = 16;
 
-  const RSA_ENC_MODE = CRYPT_RSA_ENCRYPTION_OAEP;
+  const RSA_ENC_MODE = \phpseclib\Crypt\RSA::ENCRYPTION_OAEP;
 
   const RSA_HASH = 'sha256';
 
-  const RSA_SIG_MODE = CRYPT_RSA_SIGNATURE_PSS;
+  const RSA_SIG_MODE = \phpseclib\Crypt\RSA::SIGNATURE_PSS;
 
   const RSA_KEYLEN = 2048;
 

--- a/src/Cxn.php
+++ b/src/Cxn.php
@@ -20,7 +20,7 @@ class Cxn {
    * @return string
    */
   public static function createId() {
-    return 'cxn:' . BinHex::bin2hex(crypt_random_string(Constants::CXN_ID_CHARS));
+    return 'cxn:' . BinHex::bin2hex(\phpseclib\Crypt\Random::string(Constants::CXN_ID_CHARS));
   }
 
   public static function validate($cxn) {

--- a/src/DefaultCertificateValidator.php
+++ b/src/DefaultCertificateValidator.php
@@ -151,7 +151,7 @@ class DefaultCertificateValidator implements CertificateValidatorInterface {
     if (!$certObj->validateSignature()) {
       throw new InvalidCertException("Identity is invalid. Certificate is not signed by proper CA.");
     }
-    if (!$certObj->validateDate(Time::getTime())) {
+    if (!$certObj->validateDate(Time::getTimeObject())) {
       throw new ExpiredCertException("Identity is invalid. Certificate expired.");
     }
   }

--- a/src/DefaultCertificateValidator.php
+++ b/src/DefaultCertificateValidator.php
@@ -106,17 +106,17 @@ class DefaultCertificateValidator implements CertificateValidatorInterface {
   protected static function validate($certPem, $caCertPem, $crlPem = NULL, $crlDistCertPem = NULL) {
     $caCertObj = X509Util::loadCACert($caCertPem);
 
-    $certObj = new \File_X509();
+    $certObj = new \phpseclib\File\X509();
     $certObj->loadCA($caCertPem);
 
     if ($crlPem !== NULL) {
-      $crlObj = new \File_X509();
+      $crlObj = new \phpseclib\File\X509();
       if ($crlDistCertPem) {
         $crlDistCertObj = X509Util::loadCrlDistCert($crlDistCertPem, NULL, $caCertPem);
-        if ($crlDistCertObj->getSubjectDN(FILE_X509_DN_STRING) !== $caCertObj->getSubjectDN(FILE_X509_DN_STRING)) {
+        if ($crlDistCertObj->getSubjectDN(\phpseclib\File\X509::DN_STRING) !== $caCertObj->getSubjectDN(\phpseclib\File\X509::DN_STRING)) {
           throw new InvalidCertException(sprintf("CRL distributor (%s) does not act on behalf of this CA (%s)",
-            $crlDistCertObj->getSubjectDN(FILE_X509_DN_STRING),
-            $caCertObj->getSubjectDN(FILE_X509_DN_STRING)
+            $crlDistCertObj->getSubjectDN(\phpseclib\File\X509::DN_STRING),
+            $caCertObj->getSubjectDN(\phpseclib\File\X509::DN_STRING)
             ));
         }
         try {

--- a/src/KeyPair.php
+++ b/src/KeyPair.php
@@ -19,7 +19,7 @@ class KeyPair {
    *   - publickey: string.
    */
   public static function create() {
-    $rsa = new \Crypt_RSA();
+    $rsa = new \phpseclib\Crypt\RSA();
     return $rsa->createKey(Constants::RSA_KEYLEN);
   }
 

--- a/src/Message/AppMetasMessage.php
+++ b/src/Message/AppMetasMessage.php
@@ -81,7 +81,7 @@ class AppMetasMessage extends Message {
     if ($certValidator !== NULL) {
       $certValidator->validateCert($wireCert);
 
-      $wireCertX509 = new \File_X509();
+      $wireCertX509 = new \phpseclib\File\X509();
       $wireCertX509->loadX509($wireCert);
 
       $cn = $wireCertX509->getDNProp('CN');
@@ -112,10 +112,10 @@ class AppMetasMessage extends Message {
    * @param string $key
    * @param string $type
    *   'public' or 'private'
-   * @return \Crypt_RSA
+   * @return \phpseclib\Crypt\RSA
    */
   public static function getRsa($key, $type) {
-    $rsa = new \Crypt_RSA();
+    $rsa = new \phpseclib\Crypt\RSA();
     $rsa->loadKey($key);
     if ($type == 'public') {
       $rsa->setPublicKey();
@@ -129,8 +129,8 @@ class AppMetasMessage extends Message {
   /**
    * Quasi-private - marked public to work-around PHP 5.3 compat.
    *
-   * @param \File_X509 $x509
-   * @return \Crypt_RSA
+   * @param \phpseclib\File\X509 $x509
+   * @return \phpseclib\Crypt\RSA
    */
   public static function getRsaFromCert($x509) {
     $rsa = $x509->getPublicKey();

--- a/src/Message/RegistrationMessage.php
+++ b/src/Message/RegistrationMessage.php
@@ -29,7 +29,7 @@ use Civi\Cxn\Rpc\Constants;
  * real data. This will allow us to expand the registration data (i.e.
  * passing along more fields) without changing the protocol.
  *
- * Note: Crypt_RSA can encrypt oversized messages using an adhoc block
+ * Note: \phpseclib\Crypt\RSA can encrypt oversized messages using an adhoc block
  * mode that smells like ECB. This doesn't compromise confidentiality,
  * but long messages could have their ciphertext spliced -- compromising
  * integrity.
@@ -114,10 +114,10 @@ class RegistrationMessage extends Message {
    * @param string $key
    * @param string $type
    *   'public' or 'private'
-   * @return \Crypt_RSA
+   * @return \phpseclib\Crypt\RSA
    */
   public static function getRsa($key, $type) {
-    $rsa = new \Crypt_RSA();
+    $rsa = new \phpseclib\Crypt\RSA();
     $rsa->loadKey($key);
     if ($type == 'public') {
       $rsa->setPublicKey();

--- a/src/RegistrationClient.php
+++ b/src/RegistrationClient.php
@@ -187,7 +187,7 @@ class RegistrationClient extends Agent {
    * @throws Exception\InvalidMessageException
    */
   protected function doCall($appMeta, $entity, $action, $params, $cxn) {
-    $appCert = new \File_X509();
+    $appCert = new \phpseclib\File\X509();
     $appCert->loadX509($appMeta['appCert']);
 
     $req = new RegistrationMessage($cxn['appId'], $appCert->getPublicKey(), array(

--- a/src/Time.php
+++ b/src/Time.php
@@ -31,6 +31,15 @@ class Time {
   }
 
   /**
+   * @return int
+   */
+  public static function getTimeObject() {
+    $time = new \DateTime();
+    $time->setTimestamp(self::getTime());
+    return $time;
+  }
+
+  /**
    * Set the given time.
    *
    * @param string $newDateTime

--- a/src/X509Util.php
+++ b/src/X509Util.php
@@ -20,10 +20,10 @@ class X509Util {
    * @param array $keyPairPems
    *   Pair of PEM-encoded keys.
    * @param string $caCertPem
-   * @return \File_X509
+   * @return \phpseclib\File\X509
    */
   public static function loadCert($certPem, $keyPairPems = NULL, $caCertPem = NULL) {
-    $certObj = new \File_X509();
+    $certObj = new \phpseclib\File\X509();
 
     if (isset($caCertPem)) {
       $certObj->loadCA($caCertPem);
@@ -34,13 +34,13 @@ class X509Util {
     }
 
     if (isset($keyPairPems['privatekey'])) {
-      $privKey = new \Crypt_RSA();
+      $privKey = new \phpseclib\Crypt\RSA();
       $privKey->loadKey($keyPairPems['privatekey']);
       $certObj->setPrivateKey($privKey);
     }
 
     if (isset($keyPairPems['publickey'])) {
-      $pubKey = new \Crypt_RSA();
+      $pubKey = new \phpseclib\Crypt\RSA();
       $pubKey->loadKey($keyPairPems['publickey']);
       $pubKey->setPublicKey();
       $certObj->setPublicKey($pubKey);
@@ -54,7 +54,7 @@ class X509Util {
    *   PEM-encoded.
    * @param array $keyPair
    *   Pair of PEM-encoded keys.
-   * @return \File_X509
+   * @return \phpseclib\File\X509
    * @throws InvalidCertException
    */
   public static function loadCACert($caCertPem, $keyPair = NULL) {
@@ -73,7 +73,7 @@ class X509Util {
    *   Pair of PEM-encoded keys.
    * @param string $caCertPem
    *   PEM-encoded.
-   * @return \File_X509
+   * @return \phpseclib\File\X509
    * @throws InvalidCertException
    */
   public static function loadCrlDistCert($crlCertPem, $keyPair = NULL, $caCertPem = NULL) {

--- a/tests/AppMetasMessageTest.php
+++ b/tests/AppMetasMessageTest.php
@@ -14,7 +14,7 @@ namespace Civi\Cxn\Rpc;
 use Civi\Cxn\Rpc\Exception\InvalidMessageException;
 use Civi\Cxn\Rpc\Message\AppMetasMessage;
 
-class AppMetasMessageTest extends \PHPUnit_Framework_TestCase {
+class AppMetasMessageTest extends \PHPUnit\Framework\TestCase {
 
   public function testSignedValid() {
     list($caKeyPair, $caCert) = $this->createCA();

--- a/tests/CATest.php
+++ b/tests/CATest.php
@@ -13,7 +13,7 @@ namespace Civi\Cxn\Rpc;
 
 use Civi\Cxn\Rpc\Exception\InvalidCertException;
 
-class CATest extends \PHPUnit_Framework_TestCase {
+class CATest extends \PHPUnit\Framework\TestCase {
 
   public function testCRL_SignedByCA() {
     // create CA

--- a/tests/CATest.php
+++ b/tests/CATest.php
@@ -23,7 +23,7 @@ class CATest extends \PHPUnit_Framework_TestCase {
 
     // create CRL
     $caCertObj = X509Util::loadCert($caCertPem, $caKeyPairPems);
-    $crlObj = new \File_X509();
+    $crlObj = new \phpseclib\File\X509();
     $crlObj->setSerialNumber(1, 10);
     $crlObj->setEndDate('+2 days');
     $crlPem = $crlObj->saveCRL($crlObj->signCRL($caCertObj, $crlObj));
@@ -53,7 +53,7 @@ class CATest extends \PHPUnit_Framework_TestCase {
     $crlDistCertObj = X509Util::loadCert($crlDistCertPem, $crlDistKeyPairPems, $caCertPem);
     $this->assertNotEmpty($crlDistCertObj);
 
-    $crlObj = new \File_X509();
+    $crlObj = new \phpseclib\File\X509();
     $crlObj->setSerialNumber(1, 10);
     $crlObj->setEndDate('+2 days');
     $crlPem = $crlObj->saveCRL($crlObj->signCRL($crlDistCertObj, $crlObj));
@@ -109,7 +109,7 @@ class CATest extends \PHPUnit_Framework_TestCase {
     $crlDistCertObj = X509Util::loadCert($crlDistCertPem, $crlDistKeyPairPems, $caCertPem);
     $this->assertNotEmpty($crlDistCertObj);
 
-    $crlObj = new \File_X509();
+    $crlObj = new \phpseclib\File\X509();
     $crlObj->setSerialNumber(1, 10);
     $crlObj->setEndDate('+2 days');
     $crlPem = $crlObj->saveCRL($crlObj->signCRL($crlDistCertObj, $crlObj));
@@ -154,7 +154,7 @@ class CATest extends \PHPUnit_Framework_TestCase {
     $crlDistCertObj = X509Util::loadCert($crlDistCertPem, $crlDistKeyPairPems, $caCertPem);
     $this->assertNotEmpty($crlDistCertObj);
 
-    $crlObj = new \File_X509();
+    $crlObj = new \phpseclib\File\X509();
     $crlObj->setSerialNumber(1, 10);
     $crlObj->setEndDate('+2 days');
     $crlPem = $crlObj->saveCRL($crlObj->signCRL($crlDistCertObj, $crlObj));

--- a/tests/Http/ViaPortHttpTest.php
+++ b/tests/Http/ViaPortHttpTest.php
@@ -19,7 +19,7 @@ use Civi\Cxn\Rpc\Message\RegistrationMessage;
 use Civi\Cxn\Rpc\Message\StdMessage;
 use Psr\Log\NullLogger;
 
-class ViaPortHttpTest extends \PHPUnit_Framework_TestCase {
+class ViaPortHttpTest extends \PHPUnit\Framework\TestCase {
 
   protected $lastCall;
 

--- a/tests/RegistrationServerTest.php
+++ b/tests/RegistrationServerTest.php
@@ -17,7 +17,7 @@ use Civi\Cxn\Rpc\Message\RegistrationMessage;
 use Civi\Cxn\Rpc\Message\StdMessage;
 use Psr\Log\NullLogger;
 
-class RegistrationServerTest extends \PHPUnit_Framework_TestCase {
+class RegistrationServerTest extends \PHPUnit\Framework\TestCase {
 
   const APP_ID = 'app:org.civicrm.demoapp';
 

--- a/tests/RoundtripTest.php
+++ b/tests/RoundtripTest.php
@@ -13,7 +13,7 @@ namespace Civi\Cxn\Rpc;
 
 use Civi\Cxn\Rpc\CxnStore\ArrayCxnStore;
 
-class RoundtripTest extends \PHPUnit_Framework_TestCase {
+class RoundtripTest extends \PHPUnit\Framework\TestCase {
 
   public function testRoundtrip() {
     $test = $this;


### PR DESCRIPTION
According to the README for phpseclib, the main change is that everything moved into the `\phpseclib` namespace.

With these patches, the unit-tests run successfully. In grepping, I can't find any more references to old-style names (`CRYPT_`, `Crypt_`, `File_`, `Math_`, `Net_`, `System_`). So it seems promsiing.

However, before we can do a merge/release, I'll need to setup a local environment  to a full `r-run` of client+server code. After that, we can update `civicrm-core`.

So far, the contract for `civicrm-cxn-rpc` doesn't seem to have changed, so it should be legit for `civicrm-core` to depend on either the old or new version of `civicrm-cxn-rpc`.